### PR TITLE
Collectibles

### DIFF
--- a/ExoLoader/AddContentPatches.cs
+++ b/ExoLoader/AddContentPatches.cs
@@ -20,7 +20,8 @@ namespace ExoLoader
             {
                 ModInstance.instance.Log("Checking CustomCharacter folders");
                 string[] charaFolders = CFileManager.GetAllCustomCharaFolders();
-                if (charaFolders != null && charaFolders.Length == 0) {
+                if (charaFolders != null && charaFolders.Length == 0)
+                {
                     ModInstance.instance.Log("Found no folder");
                     return;
                 }
@@ -31,12 +32,14 @@ namespace ExoLoader
                     try
                     {
                         data = CFileManager.ParseCustomData(folder);
-                    } catch (Exception e)
+                    }
+                    catch (Exception e)
                     {
                         if (e is InvalidCastException)
                         {
                             DataDebugHelper.PrintDataError("Invalid cast when loading character " + Path.GetFileNameWithoutExtension(folder), "This happens when there is missing quotation marks in the json, or if you put text where a number should be. Make sure everything is in order!");
-                        } else
+                        }
+                        else
                         {
                             DataDebugHelper.PrintDataError("Unexpected error when loading " + Path.GetFileNameWithoutExtension(folder), e.Message);
                         }
@@ -76,11 +79,13 @@ namespace ExoLoader
                     ModInstance.log("Added " + counter + " image names to the list");
 
                 }
-            } else if (filename == "ExocolonistCards - cards")
+            }
+            else if (filename == "ExocolonistCards - cards")
             {
                 ModInstance.log("calling LoadCustomContent for Cards");
                 LoadCustomContent("Cards");
-            } else if (filename == "Exocolonist - variables")
+            }
+            else if (filename == "Exocolonist - variables")
             {
                 ModInstance.log("Loading preliminary content");
 
@@ -93,13 +98,18 @@ namespace ExoLoader
                 ModInstance.log("Loading custom backgrounds");
                 LoadCustomContent("Backgrounds");
 
-            } else if (filename == "Exocolonist - jobs")
+            }
+            else if (filename == "Exocolonist - jobs")
             {
                 LoadCustomContent("Jobs");
             }
             else if (filename == "Exocolonist - endings")
             {
                 LoadCustomContent("Endings");
+            }
+            else if (filename == "ExocolonistCards - collectibles")
+            {
+                LoadCustomContent("Collectibles");
             }
         }
 

--- a/ExoLoader/CustomContentParser.cs
+++ b/ExoLoader/CustomContentParser.cs
@@ -41,67 +41,75 @@ namespace ExoLoader
             "Preamble"
         };
 
+        private static readonly string[] expectedCollectibleEntries = new string[]
+        {
+            "ID",
+            "Name",
+            "Plural",
+        };
+
         public static void ParseContentFolder(string contentFolderPath, string contentType)
         {
             string[] folders = Directory.GetDirectories(contentFolderPath);
             foreach (string folder in folders)
             {
                 string folderName = Path.GetFileName(folder);
-                if (folderName.Equals(contentType)) { 
+                if (folderName.Equals(contentType))
+                {
                     switch (folderName)
                     {
                         case "Cards":
-                        {
-                            ModInstance.log("Parsing cards folder");
-                            foreach (string file in Directory.GetFiles(folder))
                             {
-                                if (file.EndsWith(".json"))
+                                ModInstance.log("Parsing cards folder");
+                                foreach (string file in Directory.GetFiles(folder))
                                 {
-                                    ModInstance.log("Parsing file : " + Path.GetFileName(file));
-                                    try
+                                    if (file.EndsWith(".json"))
                                     {
+                                        ModInstance.log("Parsing file : " + Path.GetFileName(file));
+                                        try
+                                        {
 
-                                        ParseCardData(file);
-                                    } 
-                                    catch (Exception ex)
-                                    {
-                                        if (ex is InvalidCastException)
-                                        {
-                                            DataDebugHelper.PrintDataError("Invalid cast when loading card " + Path.GetFileNameWithoutExtension(file), "This happens when there is missing quotation marks in the json, or if you put text where a number should be. Make sure everything is in order!");
+                                            ParseCardData(file);
                                         }
-                                        else
+                                        catch (Exception ex)
                                         {
-                                            DataDebugHelper.PrintDataError("Unexpected error when loading " + Path.GetFileNameWithoutExtension(file), ex.Message);
+                                            if (ex is InvalidCastException)
+                                            {
+                                                DataDebugHelper.PrintDataError("Invalid cast when loading card " + Path.GetFileNameWithoutExtension(file), "This happens when there is missing quotation marks in the json, or if you put text where a number should be. Make sure everything is in order!");
+                                            }
+                                            else
+                                            {
+                                                DataDebugHelper.PrintDataError("Unexpected error when loading " + Path.GetFileNameWithoutExtension(file), ex.Message);
+                                            }
+                                            throw ex;
                                         }
-                                        throw ex;
                                     }
                                 }
-                            }
 
-                            break;
-                        }
+                                break;
+                            }
                         case "Backgrounds":
-                        {
-                            ModInstance.log("Adding backgrounds and CGs");
-                            List<string> cBgs = new List<string>(Singleton<AssetManager>.instance.backgroundAndEndingNames);
-                            foreach (string file in Directory.GetFiles(folder))
                             {
-                                if (file.EndsWith(".png"))
+                                ModInstance.log("Adding backgrounds and CGs");
+                                List<string> cBgs = new List<string>(Singleton<AssetManager>.instance.backgroundAndEndingNames);
+                                foreach (string file in Directory.GetFiles(folder))
                                 {
-                                    string bgName = Path.GetFileName(file).Replace(".png", "");
-                                    if (!Singleton<AssetManager>.instance.backgroundAndEndingNames.Contains(bgName))
+                                    if (file.EndsWith(".png"))
                                     {
-                                        ModInstance.log("Found bg " +  bgName);
-                                        cBgs.Add(bgName);
-                                        Singleton<AssetManager>.instance.backgroundAndEndingNames.Append(bgName);
-                                        customBackgrounds.Add(bgName, folder);
-                                        ModInstance.log("Added " + bgName + "to list");
+                                        string bgName = Path.GetFileName(file).Replace(".png", "");
+                                        if (!Singleton<AssetManager>.instance.backgroundAndEndingNames.Contains(bgName))
+                                        {
+                                            ModInstance.log("Found bg " + bgName);
+                                            cBgs.Add(bgName);
+                                            Singleton<AssetManager>.instance.backgroundAndEndingNames.Append(bgName);
+                                            customBackgrounds.Add(bgName, folder);
+                                            ModInstance.log("Added " + bgName + "to list");
+                                        }
                                     }
                                 }
+                                Singleton<AssetManager>.instance.backgroundAndEndingNames = cBgs.ToArray();
+                                break;
                             }
-                            Singleton<AssetManager>.instance.backgroundAndEndingNames = cBgs.ToArray();
-                            break;
-                        }
                         case "Jobs":
                             {
                                 ModInstance.log("Parsing job folders");
@@ -164,9 +172,164 @@ namespace ExoLoader
                                 }
                                 break;
                             }
+                        case "Collectibles":
+                            {
+                                ModInstance.log("Parsing collectibles folders");
+                                foreach (string jobFolder in CFileManager.GetAllCustomContentFolders("Collectibles"))
+                                {
+                                    foreach (string file in Directory.GetFiles(jobFolder))
+                                    {
+                                        if (file.EndsWith(".json"))
+                                        {
+                                            ModInstance.log("Found collectible file " + Path.GetFileName(file) + ", parsing...");
+                                            try
+                                            {
+                                                ParseCollectibleData(file);
+                                            }
+                                            catch (Exception ex)
+                                            {
+                                                if (ex is InvalidCastException)
+                                                {
+                                                    DataDebugHelper.PrintDataError("Invalid cast when loading collectible " + Path.GetFileNameWithoutExtension(file), "This happens when there is missing quotation marks in the json, or if you put text where a number should be. Make sure everything is in order!");
+                                                }
+                                                else
+                                                {
+                                                    DataDebugHelper.PrintDataError("Unexpected error when loading collectible " + Path.GetFileNameWithoutExtension(file), ex.Message);
+                                                }
+                                                throw ex;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+                            }
                     }
                 }
             }
+        }
+
+        private static void ParseCollectibleData(string file)
+        {
+            string fullJson = File.ReadAllText(file);
+
+            if (fullJson == null || fullJson.Length == 0)
+            {
+                DataDebugHelper.PrintDataError("Couldn't read json file for " + Path.GetFileName(file));
+                ModInstance.instance.Log("Couldn't read text for " + Path.GetFileNameWithoutExtension(file));
+                return;
+            }
+
+            Dictionary<string, object> data = JsonConvert.DeserializeObject<Dictionary<string, object>>(fullJson);
+
+            if (data == null || data.Count == 0)
+            {
+                DataDebugHelper.PrintDataError("Couldn't parse json file for " + Path.GetFileNameWithoutExtension(file), "Json file could be read as text but the text coudln't be parsed. Check for any missing \",{}, or comma");
+                ModInstance.instance.Log("Couldn't parse json for " + Path.GetFileName(file));
+                return;
+            }
+
+            List<string> missingKeys = new List<string>() { "The following keys are mandatory for a collectible file but were missing:" };
+            foreach (string key in expectedCollectibleEntries)
+            {
+                if (!data.ContainsKey(key))
+                {
+                    missingKeys.Add(key);
+                }
+            }
+
+            if (missingKeys.Count > 1)
+            {
+                DataDebugHelper.PrintDataError("Missing mandatory keys for collectible " + Path.GetFileNameWithoutExtension(file), missingKeys.ToArray());
+                return;
+            }
+
+            CustomCollectible collectible = new()
+            {
+                file = file,
+                id = (string)data["ID"],
+                name = (string)data["Name"],
+                namePlural = (string)data["Plural"],
+                cardId = (string)data["ID"],
+
+                // like and dislike are optional fields of strings separated by commans, we need to split them into arrays
+                like = data.ContainsKey("Like") ? [.. ((string)data["Like"]).Split(',').Select(l => l.Trim())] : [],
+                dislike = data.ContainsKey("Dislike") ? [.. ((string)data["Dislike"]).Split(',').Select(d => d.Trim())] : []
+            };
+
+            // Card specific fields
+            if (data.TryGetValue("HowGet", out object howGetValue))
+            {
+                collectible.howGet = ((string)howGetValue).ToLower() switch
+                {
+                    "unique" => HowGet.unique,
+                    "training" => HowGet.training,
+                    "trainingbuy" => HowGet.trainingBuy,
+                    "shopdefault" => HowGet.shopDefault,
+                    "shopclothes" => HowGet.shopClothes,
+                    "shopweapons" => HowGet.shopWeapons,
+                    "shopgadgets" => HowGet.shopGadgets,
+                    _ => HowGet.none,
+                };
+            }
+            else
+            {
+                collectible.howGet = HowGet.none; // default value
+            }
+
+            if (data.TryGetValue("Kudos", out object kudoCost))
+            {
+                collectible.kudoCost = ((string)kudoCost).ParseInt();
+            }
+
+            if (data.TryGetValue("ArtistName", out object artistName))
+            {
+                collectible.artist = (string)artistName;
+            }
+            if (data.TryGetValue("ArtistSocialAt", out object artistAt))
+            {
+                collectible.artistAt = (string)artistAt;
+            }
+
+            if (data.TryGetValue("ArtistLink", out object artistLink))
+            {
+                collectible.artistLink = (string)artistLink;
+            }
+
+            List<CardAbilityType> abilities = [];
+            List<int> values = [];
+            List<CardSuit> suits = [];
+
+            for (int i = 1; i <= 3; i++)
+            {
+                if (data.TryGetValue("Ability" + i.ToString(), out object abilityEntry))
+                {
+                    Dictionary<string, object> abilityMap;
+
+                    abilityMap = ((JObject)abilityEntry).ToObject<Dictionary<string, object>>();
+
+                    ModInstance.log("Reading an Ability entry");
+                    string abID = (string)abilityMap.GetValueSafe("ID");
+                    CardAbilityType abType = CardAbilityType.FromID(abID);
+                    if (abType != null)
+                    {
+                        abilities.Add(abType);
+
+                        values.Add(((string)abilityMap.GetValueSafe("Value")).ParseInt());
+                        suits.Add(((string)abilityMap.GetValueSafe("Suit")).ParseEnum<CardSuit>());
+                    }
+                    else if (abID != null && abID != "")
+                    {
+                        DataDebugHelper.PrintDataError("Invalid ability in " + Path.GetFileNameWithoutExtension(file));
+                        ModInstance.log("WARNING: Incorrect Ability ID : " + abID);
+                    }
+                }
+            }
+
+            collectible.abilityIds = abilities;
+            collectible.abilityValues = values;
+            collectible.abilitySuits = suits;
+
+            collectible.MakeCollectible();
         }
 
         private static void ParseCardData(string file)
@@ -209,7 +372,7 @@ namespace ExoLoader
             {
                 case "memory":
                     {
-                        cardData.type = CardType.memory; 
+                        cardData.type = CardType.memory;
                         break;
                     }
                 case "gear":
@@ -225,7 +388,7 @@ namespace ExoLoader
             }
 
             cardData.value = ((string)data["Value"]).ParseInt();
-            
+
 
             switch (((string)data["Suit"]).ToLower())
             {
@@ -249,9 +412,14 @@ namespace ExoLoader
                         cardData.suit = CardSuit.wildcard;
                         break;
                     }
+                case "none":
+                    {
+                        cardData.suit = CardSuit.none;
+                        break;
+                    }
                 default:
                     {
-                        DataDebugHelper.PrintDataError(Path.GetFileNameWithoutExtension(file) + "has invalid suit", "Valid suits are limited to wild, physical, mental and social");
+                        DataDebugHelper.PrintDataError(Path.GetFileNameWithoutExtension(file) + "has invalid suit", "Valid suits are limited to none, wild, physical, mental and social");
                         break;
                     }
             }
@@ -362,7 +530,8 @@ namespace ExoLoader
 
                         values.Add(((string)abilityMap.GetValueSafe("Value")).ParseInt());
                         suits.Add(((string)abilityMap.GetValueSafe("Suit")).ParseEnum<CardSuit>());
-                    } else if (abID != null && abID != "")
+                    }
+                    else if (abID != null && abID != "")
                     {
                         DataDebugHelper.PrintDataError("Invalid ability in " + Path.GetFileNameWithoutExtension(file));
                         ModInstance.log("WARNING: Incorrect Ability ID : " + abID);

--- a/ExoLoader/CustomElements/CustomCollectible.cs
+++ b/ExoLoader/CustomElements/CustomCollectible.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using HarmonyLib;
+using UnityEngine;
+
+namespace ExoLoader
+{
+    public class CustomCollectible
+    {
+        public static Dictionary<string, string> idToFile = new Dictionary<string, string>();
+        public static Dictionary<string, CustomCollectible> customCollectiblesById = new Dictionary<string, CustomCollectible>();
+
+        public string file;
+        public string id;
+        public string name;
+        public string namePlural;
+        public string cardId;
+        public int chance;
+        public bool isPlant;
+
+        // To populate to the chara data
+        public string[] like;
+        public string[] dislike;
+
+        // To populate to the card data
+        public HowGet howGet;
+        public string artist;
+        public string artistAt;
+        public string artistLink;
+        public int kudoCost = 0;
+        public List<CardAbilityType> abilityIds = new List<CardAbilityType>();
+        public List<int> abilityValues = new List<int>();
+        public List<CardSuit> abilitySuits = new List<CardSuit>();
+
+        public void MakeCollectible()
+        {
+            customCollectiblesById.Add(id, this);
+
+            ModInstance.log("----> Adding collectible to dictionary, id = " + id + ", file = " + file);
+            idToFile.Add(id, file);
+
+            // First create a card
+            CustomCardData card = new CustomCardData
+            {
+                file = file,
+                id = cardId,
+                name = name,
+                type = CardType.collectible,
+                suit = CardSuit.none, // Collectibles don't have a suit
+                level = 1,
+                howGet = howGet,
+                value = 1,
+                upgradeFromCardID = null,
+                artist = artist,
+                artistAt = artistAt,
+                artistLink = artistLink,
+                kudoCost = kudoCost,
+                abilityIds = abilityIds,
+                abilityValues = abilityValues,
+                abilitySuits = abilitySuits
+            };
+
+            card.MakeCard();
+
+            CardData cardData = CardData.FromID(cardId);
+
+            if (cardData == null)
+            {
+                ModInstance.log($"Error adding a card for collectible {id}. CardData is null.");
+                return;
+            }
+
+            bool hasBattleEffect = abilityIds.Count > 0;
+
+            // Create the collectible
+            Collectible collectible = new Collectible(id, name, namePlural, cardData, chance, [], [], isPlant, hasBattleEffect);
+
+            // If we have like/dislikes, find characters by the ids in like/dislike and add item there
+            if (like != null && like.Length > 0)
+            {
+                foreach (string charaId in like)
+                {
+                    Chara chara = Chara.FromID(charaId);
+                    if (chara != null)
+                    {
+                        if (!chara.likedCards.Contains(cardData))
+                        {
+                            chara.likedCards.Add(cardData);
+                            ModInstance.log($"Added collectible {id} to liked cards of character {charaId}.");
+                        }
+                        else
+                        {
+                            ModInstance.log($"Collectible {id} already exists in liked cards of character {charaId}.");
+                        }
+                    }
+                    else
+                    {
+                        ModInstance.log($"Character with ID {charaId} not found for collectible {id}.");
+                    }
+                }
+            }
+
+            if (dislike != null && dislike.Length > 0)
+            {
+                foreach (string charaId in dislike)
+                {
+                    Chara chara = Chara.FromID(charaId);
+                    if (chara != null)
+                    {
+                        if (!chara.dislikedCards.Contains(cardData))
+                        {
+                            chara.dislikedCards.Add(cardData);
+                            ModInstance.log($"Added collectible {id} to disliked cards of character {charaId}.");
+                        }
+                        else
+                        {
+                            ModInstance.log($"Collectible {id} already exists in disliked cards of character {charaId}.");
+                        }
+                    }
+                    else
+                    {
+                        ModInstance.log($"Character with ID {charaId} not found for collectible {id}.");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Separated from cards, because you can technically add them to the map and that requires a bit of extra logic. I do have a mostly working implementation of adding custom collectibles to the overworld, but there is one nasty issue, so I've decided to scrap it for now, since the use case is a bit limited as that would end up competing with existing collectibles for the spawn points.

Custom collectibles should be added to `Collectibles` folder, format similar to cards - one json file, one png file for the card itself.
Example JSON:

```
{
	"ID": "templatecollectible",
	"Name": "Template",
	"Plural": "Templates",
	"HowGet": "shopDefault", // can be none or left out completely
	"Kudos": "10", // only for shop items
	"Like": "sym, dys, spellalt", // optional, but every collectible in the game has sym in like :D
	"Dislike": "tang", // optional
	"ArtistName": "Poayo_",
	"ArtistSocialAt": "",
	"ArtistLink": "",
	"Ability1": {
		"ID": "collectiblePlusSuit",
		"Value": "2",
		"Suit": "mental"
	},
	"Ability2": {
		"ID": "",
		"Value": "",
		"Suit": ""
	},
	"Ability3": {
		"ID": "",
		"Value": "",
		"Suit": ""
	}
}
```


Note: for likes/dislikes, this only affects rep gain/loss when gifting. The custom flavor text can be added via story patches.
Note2: VSCode applied some more formatting "fixes" when I touched something...